### PR TITLE
Update the size of the Two Colours arena for the SR2020 rules

### DIFF
--- a/sr/robot/arenas/two_colours_arena.py
+++ b/sr/robot/arenas/two_colours_arena.py
@@ -9,10 +9,10 @@ from arena import ARENA_MARKINGS_COLOR, ARENA_MARKINGS_WIDTH, Arena
 from ..markers import Token
 from ..vision import MARKER_TOKEN_GOLD, MARKER_TOKEN_SILVER
 
-HOME_ZONE_SIZE = 3
+HOME_ZONE_SIZE = 2.5
 
 INNER_CIRCLE_RADIUS = 0.42
-OUTER_CIRCLE_RADIUS = 1.3
+OUTER_CIRCLE_RADIUS = 1.25  # Some tokens are at 1200ish, others at 1270ish
 TOKENS_PER_CIRCLE = 8
 PEDESTAL_COLOR = (0x80, 0x80, 0x80)
 
@@ -38,10 +38,12 @@ class SilverToken(Token):
 
 
 class TwoColoursArena(Arena):
-    start_locations = [(-3.6, -3.6),
-                       (3.6, -3.6),
-                       (3.6, 3.6),
-                       (-3.6, 3.6)]
+    size = (5.75, 5.75)
+
+    start_locations = [(-2.6, -2.6),
+                       (2.6, -2.6),
+                       (2.6, 2.6),
+                       (-2.6, 2.6)]
 
     start_headings = [0.25 * pi,
                       0.75 * pi,

--- a/sr/robot/display.py
+++ b/sr/robot/display.py
@@ -13,11 +13,21 @@ def get_surface(name):
 
     return sprites[name]
 
+
+def _int_without_remainder(val):
+    as_int = int(val)
+    assert as_int == val, "Unable to convert {!r} to integer - it has a fractional part".format(val)
+    return as_int
+
+
 class Display(object):
     def __init__(self, arena):
         self.arena = arena
         arena_w, arena_h = self.arena.size
-        self.size = (arena_w * PIXELS_PER_METER, arena_h * PIXELS_PER_METER)
+        self.size = (
+            _int_without_remainder(arena_w * PIXELS_PER_METER),
+            _int_without_remainder(arena_h * PIXELS_PER_METER),
+        )
 
         pygame.display.init()
         self._window = pygame.display.set_mode(self.size)


### PR DESCRIPTION
Specifically, this shrinks the arena to 5.75m and the scoring zones to 2.5m.
This also makes the spacing of the tokens more closely match the rules now there's less room for inaccuracy.

Fixes https://github.com/srobo/tasks/issues/370.