### PR TITLE
use pip instead of brew for pygame install

### DIFF
--- a/install-macosx.command
+++ b/install-macosx.command
@@ -7,10 +7,7 @@ brew --version > /dev/null || (echo 'No Homebrew detected. Please install Homebr
 export PATH=/usr/local/bin:$PATH
 set -v
 brew install python
-brew install pygame
+pip install pygame
 pip install pyyaml
 pip install pypybox2d
 set +v
-
-# Create runner script
-


### PR DESCRIPTION
installing pygame with brew isn't the recommended method any more
(Not sure if it was to begin with). So lets use pip.